### PR TITLE
fxload in debian is in /sbin. That's not guaranteed to be on PATH

### DIFF
--- a/hdmi2usb/modeswitch/boards.py
+++ b/hdmi2usb/modeswitch/boards.py
@@ -122,8 +122,12 @@ def load_fx2(board, mode=None, filename=None, verbose=False):
     if verbose:
         sys.stderr.write("Running %r\n" % " ".join(cmdline))
 
+    env = os.environ.copy()
+    env['PATH'] = env['PATH'] + ':/usr/sbin:/sbin'
+
     try:
-        output = subprocess.check_output(cmdline, stderr=subprocess.STDOUT)
+        output = subprocess.check_output(cmdline, stderr=subprocess.STDOUT,
+                                         env=env)
     except subprocess.CalledProcessError as e:
         if b"can't modify CPUCS: Protocol error\n" not in e.output:
             print(e.output)


### PR DESCRIPTION
The user should have permission to write to the usb device, if the udev rules are installed, so they don't actually have to be root.