### PR TITLE
Setuptools PEP8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ conda:
 	pip install pyusb
 	pip install pep8
 	pip install autopep8
+	pip install setuptools-pep8
 	python3 setup.py develop
 
 check-conda:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 
 from setuptools import find_packages
 from setuptools import setup
-import os
 import sys
 
 import versioneer
@@ -11,12 +10,6 @@ import versioneer
 
 if sys.version_info[:3] < (3, 3):
     raise SystemExit("You need Python 3.3+")
-
-
-if os.environ.get('PYBUILD_NAME'):
-    setup_requires = []
-else:
-    setup_requires = ['setuptools-pep8']
 
 
 setup(
@@ -54,7 +47,6 @@ setup(
 #        ('/etc/udev/rules.d/', os.listdir(udev,
 #            "*-hdmi2usb-*.rules", "hdmi2usb-*.sh"),
 #    ],
-    setup_requires=setup_requires,
     include_package_data=True,
     entry_points={
         "console_scripts": [x+"=hdmi2usb.modeswitch.cli:main" for x in (


### PR DESCRIPTION
We only really care about `setuptools-pep8` in Travis, so install it there.