### PR TITLE
Add test device IDs to board list

### DIFF
--- a/USB-IDs.md
+++ b/USB-IDs.md
@@ -1,24 +1,43 @@
 # USB ID table
 
  * This page is published at https://github.com/timvideos/HDMI2USB/wiki/USB-IDs
- * [More information about the Opsis USB IDs can be found in the developer documentation](https://github.com/timvideos/HDMI2USB/wiki/USB-IDs/_edit).
+ * [More information about the Opsis USB IDs can be found in the developer documentation](https://opsis.hdmi2usb.tv/getting-started/usb-ids.html).
 
 ### Primary USB IDs
 
-| Board |    Mode        | Vendor ID | Product ID |
-| -----:| --------------:|:---------:|:----------:|
-| Opsis | Unconfigured   | 0x2A19    | 0x5440     |
-| Opsis | Programming    | 0x2A19    | 0x5441     |
-| Opsis | Operational    | 0x2A19    | 0x5442     |
-| Atlys | Digilent Adept*| 0x1443    | 0x0007     |
-| Atlys | Unconfigured   | 0x1D50    | 0x60b5     |
-| Atlys | Programming    | 0x1D50    | 0x60b6     |
-| Atlys | Operational    | 0x1D50    | 0x60b7     |
+| Board |    Mode        | Vendor ID | Product ID | Device ID  |
+| -----:| --------------:|:---------:|:----------:|:----------:|
+| Opsis | Unconfigured   | 0x2A19    | 0x5440     | FIXME      |
+| Opsis | Upgrade        | 0x2A19    | 0x5441     | 0x01       |
+| Opsis | Operational    | 0x2A19    | 0x5442     | FIXME      |
+| Atlys | Digilent Adept*| 0x1443    | 0x0007     | FIXME      |
+| Atlys | Unconfigured   | 0x1D50    | 0x60b5     | 0x01       |
+| Atlys | Upgrade        | 0x1D50    | 0x60b6     | 0x01       |
+| Atlys | Operational    | 0x1D50    | 0x60b6     | 0x01       |
 
  *: Atlys running original shipping firmware enumerates as this.
 
 For the Opsis, we use Numato Lab's USB ID (they are  the device's manufacture).
 For the Atlys, the [Openmoko project](http://wiki.openmoko.org/wiki/USB_Product_IDs#Assigned.2FAllocated_Openmoko_USB_Product_IDs) has provided IDs.
+
+### Developer IDs
+
+Developer modes reuse a different DeviceID on the "Upgrade" PID+VID
+
+| Board |    Mode        | Vendor ID | Product ID | Device ID  |
+| -----:| --------------:|:---------:|:----------:|:----------:|
+| Opsis | Test JTAG      | 0x2A19    | 0x5441     | 0x10       |
+| Opsis | Test Serial    | 0x2A19    | 0x5441     | 0x11       |
+| Opsis | Test Audio     | 0x2A19    | 0x5441     | 0x12       |
+| Opsis | Test UVC       | 0x2A19    | 0x5441     | 0x13       |
+| Atlys | Test JTAG      | 0x1D50    | 0x60b7     | 0x10       |
+| Atlys | Test Serial    | 0x1D50    | 0x60b7     | 0x11       |
+| Atlys | Test Audio     | 0x1D50    | 0x60b7     | 0x12       |
+| Atlys | Test UVC       | 0x1D50    | 0x60b7     | 0x13       |
+| MiniBoard | Unconfigured * | ??        | ???     | ???        |
+| MiniBoard | Test Serial    | 0x1D50    | ???     | 0x11       |
+| MiniBoard | Test Audio     | 0x1D50    | ???     | 0x12       |
+| MiniBoard | Test UVC       | 0x1D50    | ???     | 0x13       |
 
 ### Other USB IDs
 
@@ -43,3 +62,16 @@ For the Atlys, the [Openmoko project](http://wiki.openmoko.org/wiki/USB_Product_
 |  0x16C0   | Van Ooijen Technische Informatica | Original developers of ixo-usb-jtag. |
 |  0x1D50   | OpenMoko, Inc.                    | Originally made phones but now have [donated their ID to open source projects](http://wiki.openmoko.org/wiki/USB_Product_IDs). |
 |  0x2A19   | Numato Lab                        | Manufacturers of the Opsis board. |
+
+-------
+
+### Currently Unused USB Ids
+
+| Vendor ID | Product ID | Current Description |
+|:---------:|:----------:|:------|
+|  0x1d50   | 0x60b8     | TimVideos' HDMI2USB (Soft+UTMI) - Unconfigured device        |
+|  0x1d50   | 0x60b9     | TimVideos' HDMI2USB (Soft+UTMI) - Firmware upgrade           |
+|  0x1d50   | 0x60ba     | TimVideos' HDMI2USB (Soft+UTMI) - HDMI/DVI Capture Device    |
+|  0x1d50   | 0x60df     | Numato Opsis HDMI2USB board - unconfigured                   |
+|  0x1d50   | 0x60e0     | Numato Opsis HDMI2USB board - JTAG Programming Mode          |
+|  0x1d50   | 0x60e1     | Numato Opsis HDMI2USB board - User Mode                      |

--- a/USB-IDs.md
+++ b/USB-IDs.md
@@ -13,7 +13,7 @@
 | Atlys | Digilent Adept*| 0x1443    | 0x0007     | FIXME      |
 | Atlys | Unconfigured   | 0x1D50    | 0x60b5     | 0x01       |
 | Atlys | Upgrade        | 0x1D50    | 0x60b6     | 0x01       |
-| Atlys | Operational    | 0x1D50    | 0x60b6     | 0x01       |
+| Atlys | Operational    | 0x1D50    | 0x60b7     | FIXME      |
 
  *: Atlys running original shipping firmware enumerates as this.
 

--- a/hdmi2usb/modeswitch/boards.py
+++ b/hdmi2usb/modeswitch/boards.py
@@ -361,18 +361,15 @@ def find_boards(prefer_hardware_serial=True, verbose=False):
             all_boards.append(
                 Board(dev=device, type="atlys", state="unconfigured"))
 
-        # Digilent Atlys board JTAG/firmware upgrade mode with Openmoko ID
+        # Digilent Atlys board JTAG/firmware upgrade mode with Openmoko ID.
+        # Device ID 0x10 indicates test JTAG mode, 0x11 indicates test Serial,
+        # 0x12 indicates test Audio and 0x13 indicates test UVC.
         # Bus 003 Device 019: ID 1d50:60b6
         elif device.vid == 0x1d50 and device.pid == 0x60b6:
-            all_boards.append(
-                Board(dev=device, type="atlys", state="jtag"))
-
-        # Digilent Atlys board JTAG/firmware upgrade mode with Openmoko ID by
-        # default. Device ID 0x10 indicates test JTAG mode, 0x11 indicates test
-        # Serial, 0x12 indicates test Audio and 0x13 indicates test UVC.
-        # Bus 003 Device 019: ID 1d50:60b7
-        elif device.vid == 0x1d50 and device.pid == 0x60b7:
-            if device.did == '0010':
+            if device.did == '0001':
+                all_boards.append(
+                    Board(dev=device, type="atlys", state="jtag"))
+            elif device.did == '0010':
                 all_boards.append(
                     Board(dev=device, type="atlys", state="test-jtag"))
             elif device.did == '0011':
@@ -386,7 +383,13 @@ def find_boards(prefer_hardware_serial=True, verbose=False):
                     Board(dev=device, type="atlys", state="test-uvc"))
             else:
                 all_boards.append(
-                    Board(dev=device, type="atlys", state="operational"))
+                    Board(dev=device, type="atlys", state="test-???"))
+
+        # Digilent Atlys board in operational mode with Openmoko ID.
+        # Bus 003 Device 019: ID 1d50:60b7
+        elif device.vid == 0x1d50 and device.pid == 0x60b7:
+            all_boards.append(
+                Board(dev=device, type="atlys", state="operational"))
 
         elif device.vid == 0x04e2 and device.pid == 0x1410:
             exart_uarts.append(device)

--- a/hdmi2usb/modeswitch/boards.py
+++ b/hdmi2usb/modeswitch/boards.py
@@ -346,6 +346,7 @@ def find_boards(prefer_hardware_serial=True, verbose=False):
         if False:
             pass
 
+        # https://github.com/timvideos/HDMI2USB/wiki/USB-IDs
         # Digilent Atlys
         # --------------------------
         # Digilent Atlys board with stock "Adept" firmware
@@ -366,11 +367,26 @@ def find_boards(prefer_hardware_serial=True, verbose=False):
             all_boards.append(
                 Board(dev=device, type="atlys", state="jtag"))
 
-        # Digilent Atlys board JTAG/firmware upgrade mode with Openmoko ID
+        # Digilent Atlys board JTAG/firmware upgrade mode with Openmoko ID by
+        # default. Device ID 0x10 indicates test JTAG mode, 0x11 indicates test
+        # Serial, 0x12 indicates test Audio and 0x13 indicates test UVC.
         # Bus 003 Device 019: ID 1d50:60b7
         elif device.vid == 0x1d50 and device.pid == 0x60b7:
-            all_boards.append(
-                Board(dev=device, type="atlys", state="operational"))
+            if device.did == '0010':
+                all_boards.append(
+                    Board(dev=device, type="atlys", state="test-jtag"))
+            elif device.did == '0011':
+                all_boards.append(
+                    Board(dev=device, type="atlys", state="test-serial"))
+            elif device.did == '0012':
+                all_boards.append(
+                    Board(dev=device, type="atlys", state="test-audio"))
+            elif device.did == '0013':
+                all_boards.append(
+                    Board(dev=device, type="atlys", state="test-uvc"))
+            else:
+                all_boards.append(
+                    Board(dev=device, type="atlys", state="operational"))
 
         elif device.vid == 0x04e2 and device.pid == 0x1410:
             exart_uarts.append(device)
@@ -411,6 +427,15 @@ def find_boards(prefer_hardware_serial=True, verbose=False):
             elif device.did == '0003':
                 all_boards.append(
                     Board(dev=device, type="opsis", state="serial"))
+            elif device.did == '0011':
+                all_boards.append(
+                    Board(dev=device, type="opsis", state="test-serial"))
+            elif device.did == '0012':
+                all_boards.append(
+                    Board(dev=device, type="opsis", state="test-audio"))
+            elif device.did == '0013':
+                all_boards.append(
+                    Board(dev=device, type="opsis", state="test-uvc"))
             else:
                 assert False, "Unknown mode: %s" % device.did
 

--- a/hdmi2usb/modeswitch/boards.py
+++ b/hdmi2usb/modeswitch/boards.py
@@ -460,8 +460,9 @@ def find_boards(prefer_hardware_serial=True, verbose=False):
                     logging.warn("Unknown usb-jtag device! %r (%s)",
                                  device.serialno, device)
                     continue
-                all_boards.append(Board(dev=device, type=USBJTAG_MAPPING[
-                                  device.serialno], state="jtag"))
+                all_boards.append(Board(
+                    dev=device, type=USBJTAG_MAPPING[device.serialno],
+                    state="jtag"))
             elif device.did == 'ff00':
                 all_boards.append(
                     Board(dev=device, type='opsis', state="jtag"))


### PR DESCRIPTION
Allows flashing of boards with test firmware (audio for example), using the USB IDs in the [wiki](https://github.com/timvideos/HDMI2USB/wiki/USB-IDs)