### PR TITLE
Replace shelling out to fxload with CypressFX.FX2 calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ conda:
 	conda config --add channels timvideos
 	conda install openocd
 	pip install pyusb
+	pip install git+https://github.com/John-K/CypressFX.git
 	pip install pep8
 	pip install autopep8
 	pip install setuptools-pep8

--- a/hdmi2usb/modeswitch/boards.py
+++ b/hdmi2usb/modeswitch/boards.py
@@ -19,7 +19,7 @@ import re
 
 from collections import namedtuple
 
-from . import lsusb as usbapi
+from . import libusb as usbapi
 from . import files
 from CypressFX import FX2
 
@@ -123,7 +123,7 @@ def load_fx2(board, mode=None, filename=None, verbose=False):
 
     sys.stderr.write("Using FX2 firmware %s\n" % filename)
 
-    fx2 = FX2(board.dev)
+    fx2 = FX2(board.dev.libusb_open())
     if not fx2:
         print("Could not intantiate FX2 from {}".format(board.dev._str()))
         raise

--- a/hdmi2usb/modeswitch/boards.py
+++ b/hdmi2usb/modeswitch/boards.py
@@ -104,7 +104,10 @@ BoardBase = namedtuple("Board", ["dev", "type", "state"])
 class Board(BoardBase):
 
     def tty(self):
-        return self.dev.tty()
+        try:
+            return self.dev.tty()
+        except AttributeError:
+            return None
 
 
 def load_fx2(board, mode=None, filename=None, verbose=False):

--- a/hdmi2usb/modeswitch/cli.py
+++ b/hdmi2usb/modeswitch/cli.py
@@ -179,7 +179,7 @@ def find_boards(args):
                 board.state,
                 board.dev.path,
             ))
-            for sp in board.dev.syspaths:
+            for sp in getattr(board.dev, "syspaths", []):
                 sys.stderr.write(" %s\n" % (sp,))
 
             if board.dev.inuse():

--- a/hdmi2usb/modeswitch/libusb.py
+++ b/hdmi2usb/modeswitch/libusb.py
@@ -46,6 +46,12 @@ class LibDevice(DeviceBase):
             if dev.is_kernel_driver_active(inf.bInterfaceNumber):
                 dev.detach_kernel_driver(inf.bInterfaceNumber)
 
+    def drivers(self):
+        if self.inuse():
+            return ["unknown"]
+        else:
+            return []
+
     def libusb_open(self):
         return usb.core.find(bus=self.path.bus, address=self.path.address)
 

--- a/hdmi2usb/modeswitch/libusb.py
+++ b/hdmi2usb/modeswitch/libusb.py
@@ -21,8 +21,7 @@ class LibDevice(DeviceBase):
     def inuse(self, dev=None):
         try:
             if dev is None:
-                dev = usb.core.find(bus=self.path.bus,
-                                    address=self.path.address)
+                dev = self.libusb_open()
 
             # config = dev.get_active_configuration()
             active = False
@@ -37,7 +36,7 @@ class LibDevice(DeviceBase):
 
     def detach(self):
         # Detach any driver currently attached.
-        dev = usb.core.find(bus=self.path.bus, address=self.path.address)
+        dev = self.libusb_open()
 
         if not self.inuse(dev):
             return True
@@ -46,6 +45,9 @@ class LibDevice(DeviceBase):
         for inf in config:
             if dev.is_kernel_driver_active(inf.bInterfaceNumber):
                 dev.detach_kernel_driver(inf.bInterfaceNumber)
+
+    def libusb_open(self):
+        return usb.core.find(bus=self.path.bus, address=self.path.address)
 
 
 Device = LibDevice


### PR DESCRIPTION
Per IRC request, addresses #9 

@mithro I don't have a setup here to test this and am unfamiliar with Conda, would appreciate any small fixes (such as the import line for CypressFX?) that may be needed to get this working.

If this proves useful, I'll work to get CypressFX submitted to pypi to remove the github pip install from Makefile.