### PR TITLE
re-trigger udev to apply new rules on existing hardware

### DIFF
--- a/udev/Makefile
+++ b/udev/Makefile
@@ -16,7 +16,8 @@ install:
 	echo "udev rules installed; 'make reload' to reload udev rules"
 
 reload:
-	sudo udevadm control --reload-rules
+	sudo udevadm control --reload-rules; \
+	sudo udevadm trigger
 
 install-reload:
 	make install


### PR DESCRIPTION
Once you have copied the new rules in place and reloaded them, udev
needs to be retriggered to request device events from the kernel for
devices which are already plugged in.