### PR TITLE
Finds last rev that built, and caches github 

### DIFF
--- a/bin/download-prebuilt-firmware.py
+++ b/bin/download-prebuilt-firmware.py
@@ -50,10 +50,10 @@ def ls_github(url, cache_ttl=None):
             else:
                 break
         cache[url] = {
-                'timestamp': datetime.now(),
-                'data': data
-                }
-        save_cache(cache)
+            'timestamp': datetime.now(),
+            'data': data
+        }
+    save_cache(cache)
 
     return data
 
@@ -237,19 +237,14 @@ def find_last_rev(args, possible_revs):
 
     possible_revs.reverse()
     archive_url = get_url(args)
-
     for rev in possible_revs:
-
         rev_url = get_rev_url(archive_url, rev)
-
         possible_platforms = get_platforms(args, rev_url)
-
         targets_url = get_targets_url(args, rev_url)
         try:
             possible_targets = get_targets(args, rev, targets_url)
             print("found at rev {}".format(rev))
             return rev
-
         except TargetNotFound:
             continue
 

--- a/bin/download-prebuilt-firmware.py
+++ b/bin/download-prebuilt-firmware.py
@@ -14,7 +14,6 @@ import urllib.request
 
 from collections import namedtuple
 from datetime import datetime
-from pprint import pprint
 
 
 class TargetNotFound(Exception):
@@ -28,7 +27,7 @@ def ls_github(url, cache_ttl=None):
     def load_cache():
         try:
             cache = pickle.load(open(cache_name, 'rb'))
-        except IOError as e:
+        except IOError:
             cache = {}
         return cache
 
@@ -251,7 +250,7 @@ def find_last_rev(args, possible_revs):
             print("found at rev {}".format(rev))
             return rev
 
-        except TargetNotFound as e:
+        except TargetNotFound:
             continue
 
 
@@ -358,7 +357,7 @@ def main():
     targets_url = get_targets_url(args, rev_url)
     try:
         possible_targets = get_targets(args, rev, targets_url)
-    except TargetNotFound as e:
+    except TargetNotFound:
         rev = find_last_rev(args, possible_revs)
         # TODO: use this rev instead.
         sys.exit(1)

--- a/bin/download-prebuilt-firmware.py
+++ b/bin/download-prebuilt-firmware.py
@@ -3,17 +3,18 @@
 # FIXME: Make this work under Python 2
 
 import argparse
-from collections import namedtuple
 import csv
-from datetime import datetime
 import doctest
 import json
 import os
 import pickle
-from pprint import pprint
 import sys
 import time
 import urllib.request
+
+from collections import namedtuple
+from datetime import datetime
+from pprint import pprint
 
 
 class TargetNotFound(Exception):
@@ -35,10 +36,9 @@ def ls_github(url, cache_ttl=None):
         pickle.dump(cache, open(cache_name, 'wb'))
 
     cache = load_cache()
-    if url in cache and \
-            (cache_ttl is None or
-                ((datetime.now()-cache[url]['timestamp']).total_seconds() <
-                    cache_ttl)):
+    if url in cache and (cache_ttl is None or (
+        (datetime.now()-cache[url]['timestamp']).total_seconds() <
+            cache_ttl)):
         data = cache[url]['data']
     else:
         while True:

--- a/bin/download-prebuilt-firmware.py
+++ b/bin/download-prebuilt-firmware.py
@@ -22,6 +22,7 @@ class TargetNotFound(Exception):
 
 def ls_github(url, cache_ttl=None):
 
+    # FIXME: Move cache to a class or find a package.
     cache_name = "github.pickle"
 
     def load_cache():
@@ -227,7 +228,6 @@ def get_targets(args, rev, targets_url):
         print("Did not find target {} for platform {} at rev {} (found {})".
               format(args.target, args.platform, rev,
                      ", ".join(possible_targets)))
-        # pprint(possible_targets)
         raise TargetNotFound()
 
     return possible_targets


### PR DESCRIPTION
if the target isn't found,

find_last_rev(args, possible_revs) - prints the last ver and exits.
```
python3 download-prebuilt-firmware.py --platform opsis
Did not find target hdmi2usb for platform opsis at rev v0.0.4-132-g8daff41 (found base, net)
try try try.,,,
found at rev v0.0.4-122-gbc7feb5
(returns to prompt)
```
so now you can decide to get it:
``` 
python3 download-prebuilt-firmware.py --platform opsis --rev v0.0.4-122-gbc7feb5
...
Downloading to: image-gateware+bios+firmware.v0.0.4-122-gbc7feb5.opsis.hdmi2usb.lm32.bin
```
ls_github(url) now saves its data to github.pickle -
2. special case for the top level dir.   Age it - reload after 20 min.



