### PR TITLE
-o name

### DIFF
--- a/bin/download-prebuilt-firmware.py
+++ b/bin/download-prebuilt-firmware.py
@@ -94,6 +94,7 @@ def parse_args():
             help='Get for a specific platform (board + expansion boards configuration).')
     parser.add_argument('--board',
             help='Alias for --platform.', dest="platform")
+
     parser.add_argument('--channel',
             help="Get latest version from in a specific channel ().",
             default="unstable")
@@ -102,6 +103,7 @@ def parse_args():
     parser.add_argument('--latest', dest="channel", action="store_const",
             help="Get the latest version.",
             const="unstable")
+
     parser.add_argument('--branch',
             help="Branch to download from.", default="master")
     parser.add_argument('--target',

--- a/bin/download-prebuilt-firmware.py
+++ b/bin/download-prebuilt-firmware.py
@@ -86,10 +86,10 @@ def parse_args():
 
     parser = argparse.ArgumentParser(
             description='Download prebuilt firmware')
-    parser.add_argument('--user',
-            help='Github user to download from.', default="timvideos")
+
     parser.add_argument('--rev',
             help='Get a specific version.')
+
     parser.add_argument('--platform',
             help='Get for a specific platform (board + expansion boards configuration).')
     parser.add_argument('--board',
@@ -104,14 +104,17 @@ def parse_args():
             help="Get the latest version.",
             const="unstable")
 
-    parser.add_argument('--branch',
-            help="Branch to download from.", default="master")
     parser.add_argument('--target',
             help="Target to download from.", default="hdmi2usb")
     parser.add_argument('--firmware',
             help="Firmware to download from.", default="firmware")
     parser.add_argument('--arch', default="lm32",
             help="Soft-CPU architecture to download from.")
+
+    parser.add_argument('--user',
+            help='Github user to download from.', default="timvideos")
+    parser.add_argument('--branch',
+            help="Branch to download from.", default="master")
 
     args = parser.parse_args()
 

--- a/bin/download-prebuilt-firmware.py
+++ b/bin/download-prebuilt-firmware.py
@@ -116,6 +116,9 @@ def parse_args():
     parser.add_argument('--branch',
             help="Branch to download from.", default="master")
 
+    parser.add_argument('-o', '--output',
+            help="Output filename.", )
+
     args = parser.parse_args()
 
     assert args.platform
@@ -346,10 +349,14 @@ def get_image_url(args, rev, filename):
 
 def download(args, rev, filename, image_url):
 
-    parts = os.path.splitext(filename)
-    out_filename = ".".join(
-        list(parts[:-1]) +
-        [str(rev), args.platform, args.target, args.arch, parts[-1][1:]])
+    if args.output:
+        out_filename = args.output
+    else:
+        parts = os.path.splitext(filename)
+        out_filename = ".".join(
+            list(parts[:-1]) +
+            [str(rev), args.platform, args.target, args.arch, parts[-1][1:]])
+
     print("Downloading to: {}".format(out_filename))
     urllib.request.urlretrieve(image_url, out_filename)
 


### PR DESCRIPTION
like wget's "  -O,  --output-document=FILE      write documents to FILE"

let's me specify a static filename to save as.

like "foo" so that the next step is "flash foo" not "flash the file that just got downloaded"  which is hard for the CI code figure out.

